### PR TITLE
SG-14226: Jira Cloud support

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2159,13 +2159,13 @@ class JIRA(object):
 
     # Users
 
-    def user(self, id, expand=None):
+    def user(self, id, expand=None, payload="username"):
         """Get a user Resource from the server.
 
         :param id: ID of the user to get
         :param expand: extra information to fetch inside each resource
         """
-        user = User(self._options, self._session)
+        user = User(self._options, self._session, payload=payload)
         params = {}
         if expand is not None:
             params['expand'] = expand

--- a/jira/client.py
+++ b/jira/client.py
@@ -2164,6 +2164,7 @@ class JIRA(object):
 
         :param id: ID of the user to get
         :param expand: extra information to fetch inside each resource
+        :param str payload: Name of the user field to match against.
         """
         user = User(self._options, self._session, payload=payload)
         params = {}

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -751,8 +751,8 @@ class Status(Resource):
 class User(Resource):
     """A JIRA user."""
 
-    def __init__(self, options, session, raw=None):
-        Resource.__init__(self, 'user?username={0}', options, session)
+    def __init__(self, options, session, raw=None, payload="username"):
+        Resource.__init__(self, 'user?%s={0}' % payload, options, session)
         if raw:
             self._parse_raw(raw)
 

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ except ImportError:
 
 
 setuptools.setup(
-    setup_requires=['pbr>=3.0.0', 'setuptools>=17.1', 'pytest-runner', 'sphinx>=1.6.5'],
+    setup_requires=['pbr>=3.0.0', 'setuptools>=17.1'],
     pbr=True)

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ except ImportError:
 
 
 setuptools.setup(
-    setup_requires=['pbr>=3.0.0', 'setuptools>=17.1'],
+    setup_requires=['pbr>=3.0.0', 'setuptools>=17.1', 'pytest-runner', 'sphinx>=1.6.5'],
     pbr=True)


### PR DESCRIPTION
The JIRA REST API supports not only `username` but also `key` and `accountId` when resolving a user. This branch adds support for those two parameter types.

The default behaviour does not change, as the username will still be used, but it allows to change the argument type.

This helps better support a local JIRA site, where the `key` for a user is not always equal to the `username`.